### PR TITLE
Switch from using raw argparser to using click.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,9 +19,19 @@ My recommended setup process is:
 Usage
 ---
 
+Basic
+
     $ python3 leech.py [[URL]]
 
 A new file will appear named `Title of the Story.epub`.
+
+This is equivalent to the slightly longer
+
+    $ python3 leech.py download [[URL]]
+
+Flushing the cache
+
+    $ python3 leech.py flush
 
 If you want to put it on a Kindle you'll have to convert it. I'd recommend [Calibre](http://calibre-ebook.com/), though you could also try using [kindlegen](http://www.amazon.com/gp/feature.html?docId=1000765211) directly.
 

--- a/leech.py
+++ b/leech.py
@@ -17,6 +17,7 @@ USER_AGENT = 'Leech/%s +http://davidlynch.org' % __version__
 
 logger = logging.getLogger(__name__)
 
+
 def configure_logging(verbose):
     if verbose:
         logging.basicConfig(
@@ -28,6 +29,7 @@ def configure_logging(verbose):
             level=logging.INFO,
             format="[%(name)s] %(message)s"
         )
+
 
 def create_session(cache):
     if cache:
@@ -45,6 +47,7 @@ def create_session(cache):
         'User-agent': USER_AGENT
     })
     return session
+
 
 def open_story(url, session, site_options):
     site, url = sites.get(url)
@@ -83,6 +86,7 @@ def open_story(url, session, site_options):
     if not story:
         raise Exception("Couldn't extract story")
     return story
+
 
 @click.group(cls=DefaultGroup, default='download', default_if_no_args=True)
 def cli():

--- a/leech.py
+++ b/leech.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 import click
-from click_default_group import DefaultGroup
-
+import http.cookiejar
+import json
+import logging
 import requests
 import requests_cache
-import http.cookiejar
-import logging
-import json
+import sqlite3
+from click_default_group import DefaultGroup
 
 import sites
 import ebook
@@ -52,6 +52,8 @@ def open_story(url, session, site_options):
     if not site:
         raise Exception("No site handler found")
 
+    logger.info("Handler: %s (%s)", site, url)
+
     default_site_options = site.get_default_options()
 
     with open('leech.json') as store_file:
@@ -95,6 +97,11 @@ def flush(verbose):
     configure_logging(verbose)
     requests_cache.install_cache('leech')
     requests_cache.clear()
+
+    conn = sqlite3.connect('leech.sqlite')
+    conn.execute("VACUUM")
+    conn.close()
+
     logger.info("Flushed cache")
 
 

--- a/leech.py
+++ b/leech.py
@@ -19,7 +19,10 @@ logger = logging.getLogger(__name__)
 
 def configure_logging(verbose):
     if verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="[%(name)s @ %(levelname)s] %(message)s"
+        )
     else:
         logging.basicConfig(
             level=logging.INFO,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ requests-cache==0.4.13
 six==1.10.0
 urllib3==1.22
 webencodings==0.5.1
+click==6.7
+click-default-group==1.2

--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -65,6 +65,10 @@ class Site:
     options = attr.ib(default=attr.Factory(dict))
 
     @staticmethod
+    def get_default_options():
+        return {}
+
+    @staticmethod
     def matches(url):
         raise NotImplementedError()
 

--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -1,7 +1,6 @@
 
 import glob
 import os
-import argparse
 import uuid
 import attr
 from bs4 import BeautifulSoup
@@ -62,11 +61,8 @@ class Site:
     extracting the content of a story from said site.
     """
     session = attr.ib()
-    args = attr.ib()
     footnotes = attr.ib(default=attr.Factory(list), init=False)
-
-    def __attrs_post_init__(self):
-        self.options = self._parse_args(self.args)
+    options = attr.ib(default=attr.Factory(dict))
 
     @staticmethod
     def matches(url):
@@ -87,14 +83,6 @@ class Site:
 
     def login(self, login_details):
         raise NotImplementedError()
-
-    def _parse_args(self, args):
-        parser = argparse.ArgumentParser()
-        self._add_arguments(parser)
-        return parser.parse_args(args)
-
-    def _add_arguments(self, parser):
-        pass
 
     def _soup(self, url, method='html5lib', **kw):
         page = self.session.get(url, **kw)

--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -62,7 +62,10 @@ class Site:
     """
     session = attr.ib()
     footnotes = attr.ib(default=attr.Factory(list), init=False)
-    options = attr.ib(default=attr.Factory(dict))
+    options = attr.ib(default=attr.Factory(
+        lambda site: site.get_default_options(),
+        True
+    ))
 
     @staticmethod
     def get_default_options():

--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -1,4 +1,5 @@
 
+import click
 import glob
 import os
 import uuid
@@ -72,8 +73,37 @@ class Site:
     ))
 
     @staticmethod
-    def get_default_options():
-        return {}
+    def get_site_specific_option_defs():
+        """Returns a list of click.option objects to add to CLI commands.
+
+        It is best practice to ensure that these names are reasonably unique
+        to ensure that they do not conflict with the core options, or other
+        sites' options. It is OK for different site's options to have the
+        same name, but pains should be taken to ensure they remain semantically
+        similar in meaning.
+        """
+        return []
+
+    @classmethod
+    def get_default_options(cls):
+        options = {}
+        for option in cls.get_site_specific_option_defs():
+            options[option.name] = option.default
+        return options
+
+    @classmethod
+    def interpret_site_specific_options(cls, **kwargs):
+        """Returns options summarizing CLI flags provided.
+
+        Only includes entries the user has explicitly provided as flags
+        / will not contain default values. For that, use get_default_options().
+        """
+        options = {}
+        for option in cls.get_site_specific_option_defs():
+            option_value = kwargs[option.name]
+            if option_value is not None:
+                options[option.name] = option_value
+        return options
 
     @staticmethod
     def matches(url):
@@ -148,6 +178,32 @@ class Site:
         return spoiler_link
 
 
+@attr.s(hash=True)
+class SiteSpecificOption:
+    """Represents a site-specific option that can be configured.
+
+    Will be added to the CLI as a click.option -- many of these
+    fields correspond to click.option arguments."""
+    name = attr.ib()
+    flag_pattern = attr.ib()
+    type = attr.ib(default=None)
+    help = attr.ib(default=None)
+    default = attr.ib(default=None)
+
+    def as_click_option(self):
+        return click.option(
+            str(self.name),
+            str(self.flag_pattern),
+            type=self.type,
+            # Note: This default not matching self.default is intentional.
+            # It ensures that we know if a flag was explicitly provided,
+            # which keeps it from overriding options set in leech.json etc.
+            # Instead, default is used in site_cls.get_default_options()
+            default=None,
+            help=self.help if self.help is not None else ""
+        )
+
+
 class SiteException(Exception):
     pass
 
@@ -161,8 +217,21 @@ def get(url):
     for site_class in _sites:
         match = site_class.matches(url)
         if match:
+            logger.info("Handler: %s (%s)", site_class, match)
             return site_class, match
     raise NotImplementedError("Could not find a handler for " + url)
+
+
+def list_site_specific_options():
+    """Returns a list of all site's click options, which will be presented to the user."""
+
+    # Ensures that duplicate options are not added twice.
+    # Especially important for subclassed sites (e.g. Xenforo sites)
+    options = set()
+
+    for site_class in _sites:
+        options.update(site_class.get_site_specific_option_defs())
+    return [option.as_click_option() for option in options]
 
 
 # And now, a particularly hacky take on a plugin system:

--- a/sites/xenforo.py
+++ b/sites/xenforo.py
@@ -40,7 +40,7 @@ class XenForo(Site):
             mark for mark in self._chapter_list(url)
             if '/members' not in mark.get('href') and '/threadmarks' not in mark.get('href')
         ]
-        marks = marks[self.options.offset:self.options.limit]
+        marks = marks[self.options['offset']:self.options['limit']]
 
         for idx, mark in enumerate(marks, 1):
             href = mark.get('href')
@@ -95,7 +95,7 @@ class XenForo(Site):
         if not links:
             raise SiteException("No links in index?")
 
-        if self.options.include_index:
+        if self.options['include_index']:
             fake_link = self._new_tag('a', href=url)
             fake_link.string = "Index"
             links.insert(0, fake_link)
@@ -151,7 +151,7 @@ class XenForo(Site):
         # spoilers don't work well, so turn them into epub footnotes
         for idx, spoiler in enumerate(post.find_all(class_='ToggleTriggerAnchor')):
             spoiler_title = spoiler.find(class_='SpoilerTitle')
-            if self.options.spoilers:
+            if self.options['skip_spoilers']:
                 link = self._footnote(spoiler.find(class_='SpoilerTarget').extract(), chapterid)
                 if spoiler_title:
                     link.string = spoiler_title.get_text()
@@ -174,12 +174,6 @@ class XenForo(Site):
             return datetime.datetime.strptime(maybe_date['title'], "%b %d, %Y at %I:%M %p")
         raise SiteException("No date", maybe_date)
 
-    def _add_arguments(self, parser):
-        parser.add_argument('--include-index', dest='include_index', action='store_true', default=False)
-        parser.add_argument('--offset', dest='offset', type=int, default=None)
-        parser.add_argument('--limit', dest='limit', type=int, default=None)
-        parser.add_argument('--skip-spoilers', dest='spoilers', action='store_false', default=True)
-
 
 class XenForoIndex(XenForo):
     @classmethod
@@ -198,8 +192,8 @@ class SpaceBattles(XenForo):
 
 
 @register
-class SpaceBattlesIndex(XenForoIndex):
-    domain = 'forums.spacebattles.com'
+class SpaceBattlesIndex(SpaceBattles, XenForoIndex):
+    pass
 
 
 @register

--- a/sites/xenforo.py
+++ b/sites/xenforo.py
@@ -10,6 +10,15 @@ class XenForo(Site):
 
     domain = False
 
+    @staticmethod
+    def get_default_options():
+        return {
+            'offset': None,
+            'limit': None,
+            'skip_spoilers': True,
+            'include_index': False,
+        }
+
     @classmethod
     def matches(cls, url):
         match = re.match(r'^(https?://%s/threads/[^/]*\d+)/?.*' % cls.domain, url)

--- a/sites/xenforo.py
+++ b/sites/xenforo.py
@@ -3,7 +3,7 @@
 import datetime
 import re
 import logging
-from . import register, Site, SiteException, Section, Chapter
+from . import register, Site, SiteException, SiteSpecificOption, Section, Chapter
 
 logger = logging.getLogger(__name__)
 
@@ -14,13 +14,33 @@ class XenForo(Site):
     domain = False
 
     @staticmethod
-    def get_default_options():
-        return {
-            'offset': None,
-            'limit': None,
-            'skip_spoilers': True,
-            'include_index': False,
-        }
+    def get_site_specific_option_defs():
+        return [
+            SiteSpecificOption(
+                'include_index',
+                '--include-index/--no-include-index',
+                default=False,
+                help="If true, the post marked as an index will be included as a chapter."
+            ),
+            SiteSpecificOption(
+                'skip_spoilers',
+                '--skip-spoilers/--include-spoilers',
+                default=True,
+                help="If true, do not transcribe any tags that are marked as a spoiler."
+            ),
+            SiteSpecificOption(
+                'offset',
+                '--offset',
+                type=int,
+                help="The chapter index to start in the chapter marks."
+            ),
+            SiteSpecificOption(
+                'limit',
+                '--limit',
+                type=int,
+                help="The chapter to end at at in the chapter marks."
+            ),
+        ]
 
     @classmethod
     def matches(cls, url):


### PR DESCRIPTION
This is a big change -- not expecting it to be merged without talking it through / can definitely be talked out of it.

I want to add a bunch of other modes / functionality. Argparser is low level / makes this sort of tricky to do. [Click](http://click.pocoo.org) is my preferred CLI toolkit because it's really nice and modular and has a bunch of contrib code that extends things well.

This PR rewrites leech.py to use click instead of argparser. This has some tradeoffs that are worth debating, I think. Unfortunately I think the cons are pretty notable with this commit alone -- it's some of the stuff this enables that makes it worth it, IMHO.

Pros:

- Makes everything really extensible (e.g. see [my (not yet ready) branch adding a simple CLI reader mode](https://github.com/Zomega/leech/tree/reader-mode)
- Strong abstraction barrier logic for loading sites away from the code that actually uses them from the CLI definition. Means that it's a lot easier to use other parts of leech in non-CLI contexts (e.g. xenforo will no longer fail if it's called as part of a larger program without args).
- Some Autocomplete / Doc behavior out of the box, much more easily possible with click-contrib stuff.
- (Personal Opinion) Subcommands are a nice way to create  a single tool that is capable of a lot of different things. The sub command paradigm is a lot easier and cleaner with click than argparse.
- All flags are listed upfront in leech.py -- it becomes mostly a just a complete definition of the CLI.

Cons:

- Adds a couple requirements (click, click-default-group), but all are extremely portable.
- Relies on decorators, which may be less familiar to beginning python developers
- Removes the ability to do per-site flags.

This should preserve the existing CLI interface with two exceptions:

1.  `leech --flush` becomes `leech flush` Because this is strictly speaking a backwards compatibility breaking change, I bumped the major version number. Happy to put it back if the minor back-incompatibility is not a concern.
2. Because the xenforo flags are now applied at top level, some previously invalid commands are now valid.

Sidenote: I think most of the xenforo flags should maybe apply to other types of sites as well, I've seen fanfiction.net stories with pre and postfixed junk posts, for instance.