### PR TITLE
Fix royalroadl.com chapter dates

### DIFF
--- a/sites/royalroad.py
+++ b/sites/royalroad.py
@@ -39,11 +39,9 @@ class RoyalRoad(Site):
 
             # Have to get exact publishing time from the chapter page
             chapter_soup = self._soup(chapter_url)
-            updated = datetime.datetime.fromtimestamp(
-                int(chapter_soup.find(class_="profile-info").find('time').get('unixtime')),
-            )
+            contents, updated = self._chapter(chapter_url)
 
-            story.add(Chapter(title=chapter.find('a', href=True).string.strip(), contents=self._chapter(chapter_url), date=updated))
+            story.add(Chapter(title=chapter.find('a', href=True).string.strip(), contents=contents, date=updated))
 
         http.client._MAXHEADERS = original_maxheaders
 
@@ -56,5 +54,7 @@ class RoyalRoad(Site):
 
         # TODO: this could be more robust, and I don't know if there's post-chapter notes anywhere as well.
         author_note = soup.find('div', class_='author-note-portlet')
+        
+        updated = int(soup.find(class_="profile-info").find('time').get('unixtime'))
 
-        return (author_note and (author_note.prettify() + '<hr/>') or '') + content.prettify()
+        return (author_note and (author_note.prettify() + '<hr/>') or '') + content.prettify(), updated

--- a/sites/royalroad.py
+++ b/sites/royalroad.py
@@ -53,6 +53,8 @@ class RoyalRoad(Site):
         # TODO: this could be more robust, and I don't know if there's post-chapter notes anywhere as well.
         author_note = soup.find('div', class_='author-note-portlet')
 
-        updated = int(soup.find(class_="profile-info").find('time').get('unixtime'))
+        updated = datetime.datetime.fromtimestamp(
+            int(soup.find(class_="profile-info").find('time').get('unixtime'))
+        )
 
         return (author_note and (author_note.prettify() + '<hr/>') or '') + content.prettify(), updated

--- a/sites/royalroad.py
+++ b/sites/royalroad.py
@@ -37,8 +37,10 @@ class RoyalRoad(Site):
         for chapter in soup.select('#chapters tbody tr[data-url]'):
             chapter_url = str(urllib.parse.urljoin(story.url, str(chapter.get('data-url'))))
 
+            # Have to get exact publishing time from the chapter page
+            chapter_soup = self._soup(chapter_url)
             updated = datetime.datetime.fromtimestamp(
-                int(chapter.find('time').get('unixtime')),
+                int(chapter_soup.find(class_="profile-info").find('time').get('unixtime')),
             )
 
             story.add(Chapter(title=chapter.find('a', href=True).string.strip(), contents=self._chapter(chapter_url), date=updated))

--- a/sites/royalroad.py
+++ b/sites/royalroad.py
@@ -37,8 +37,6 @@ class RoyalRoad(Site):
         for chapter in soup.select('#chapters tbody tr[data-url]'):
             chapter_url = str(urllib.parse.urljoin(story.url, str(chapter.get('data-url'))))
 
-            # Have to get exact publishing time from the chapter page
-            chapter_soup = self._soup(chapter_url)
             contents, updated = self._chapter(chapter_url)
 
             story.add(Chapter(title=chapter.find('a', href=True).string.strip(), contents=contents, date=updated))
@@ -54,7 +52,7 @@ class RoyalRoad(Site):
 
         # TODO: this could be more robust, and I don't know if there's post-chapter notes anywhere as well.
         author_note = soup.find('div', class_='author-note-portlet')
-        
+
         updated = int(soup.find(class_="profile-info").find('time').get('unixtime'))
 
         return (author_note and (author_note.prettify() + '<hr/>') or '') + content.prettify(), updated


### PR DESCRIPTION
Since the timestamp provided with the chapter list is approximate, fetch
the actual chapter in order to get unixtime.