### PR TITLE
Creates a read subcommand that allows for reading the story in terminal.

### DIFF
--- a/leech.py
+++ b/leech.py
@@ -12,6 +12,7 @@ from functools import reduce
 
 import sites
 import ebook
+import reader
 
 __version__ = 2
 USER_AGENT = 'Leech/%s +http://davidlynch.org' % __version__
@@ -151,6 +152,28 @@ def download(url, site_options, cache, verbose, **other_flags):
 
     filename = ebook.generate_epub(story, options)
     logger.info("File created: " + filename)
+
+
+@cli.command()
+@click.argument('url')
+@click.option(
+    '--site-options',
+    default='{}',
+    help='JSON object encoding any site specific option.'
+)
+@click.option('--cache/--no-cache', default=True)
+@click.option('--verbose', '-v', is_flag=True, help="Verbose debugging output")
+@site_specific_options  # Includes other click.options specific to sites
+def read(url, site_options, cache, verbose, **other_flags):
+    """Launches an in terminal reader to preview or read a story."""
+    configure_logging(verbose)
+    session = create_session(cache)
+
+    site, url = sites.get(url)
+    options, login = create_options(site, site_options, other_flags)
+    story = open_story(site, url, session, login, options)
+
+    reader.launch_reader(story)
 
 
 if __name__ == '__main__':

--- a/reader/__init__.py
+++ b/reader/__init__.py
@@ -1,0 +1,47 @@
+import pypandoc
+import pydoc
+import pick
+import sys
+
+
+def description(description):
+    """Decorator to make it possible to quickly attach a description to a function or class."""
+    def wrapper(action):
+        action.description = description
+        return action
+    return wrapper
+
+
+def launch_reader(story):
+    chapters = story.contents
+    chapter_index = -1
+
+    @description('Next Chapter')
+    def next_chapter_action():
+        nonlocal chapter_index
+        chapter_index += 1
+
+    @description('Start from the Beginning')
+    def start_from_beginning_action():
+        nonlocal chapter_index
+        chapter_index = 0
+
+    @description('Select Chapter')
+    def select_chapter_action():
+        nonlocal chapter_index
+        _, chapter_index = pick.pick(
+            [chapter.title for chapter in chapters],
+            "Which chapter?",
+            default_index=max(0, chapter_index)
+        )
+
+    @description('Quit')
+    def quit_action():
+        sys.exit(0)
+
+    actions = [next_chapter_action, start_from_beginning_action, select_chapter_action, quit_action]
+
+    while True:
+        _, action_index = pick.pick([action.description for action in actions], "What to do?")
+        actions[action_index]()
+        pydoc.pager(pypandoc.convert_text(chapters[chapter_index].contents, 'rst', format='html'))


### PR DESCRIPTION
This is a pretty simple reader -- I use pandoc to convert to markdown, and pydoc to display the content in a nice pager interface.

I use this for previewing and reading over SSH when making a full EPUB is too heavy weight.

May be beyond scope of leech, but I find it handy when I'm just trying to read a single update, and not interested in sending an epub to my reader. Notable problems include that it's overkill to load the entire story just to view a chapter.