### PR TITLE
Fix FictionLive download failure on missing vote node

### DIFF
--- a/sites/fictionlive.py
+++ b/sites/fictionlive.py
@@ -55,6 +55,9 @@ class FictionLive(Site):
                 if segment['nt'] == 'chapter':
                     html.extend(('<div>', segment['b'].replace('<br>', '<br/>'), '</div>'))
                 elif segment['nt'] == 'choice':
+                    if not 'votes' in segment:
+                        # Somehow, sometime, we end up with a choice without votes (or choices)
+                        continue
                     votes = {}
                     for vote in segment['votes']:
                         votechoices = segment['votes'][vote]

--- a/sites/fictionlive.py
+++ b/sites/fictionlive.py
@@ -55,7 +55,7 @@ class FictionLive(Site):
                 if segment['nt'] == 'chapter':
                     html.extend(('<div>', segment['b'].replace('<br>', '<br/>'), '</div>'))
                 elif segment['nt'] == 'choice':
-                    if not 'votes' in segment:
+                    if 'votes' not in segment:
                         # Somehow, sometime, we end up with a choice without votes (or choices)
                         continue
                     votes = {}


### PR DESCRIPTION
Ran into the following while downloading:
```
python leech.py https://fiction.live/stories/Tutelary-God-Quest/Q95BoG6GyPuXbytYg
[sites] Handler: <class 'sites.fictionlive.FictionLive'> (https://fiction.live/stories/Tutelary-God-Quest/Q95BoG6GyPuXbytYg)
[sites.fictionlive] Extracting chapter "Chapter 1: The God of the Island" @ https://fiction.live/api/anonkun/chapters/Q95BoG6GyPuXbytYg/1500390147475/1502755126189
<snip>
[sites.fictionlive] Extracting chapter "Chapter 12: Summer of the Dead" @ https://fiction.live/api/anonkun/chapters/Q95BoG6GyPuXbytYg/1533004843289/1538444030994
Traceback (most recent call last):
  File "leech.py", line 159, in <module>
    cli()
  File "C:\Program Files\Python35\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "C:\Program Files\Python35\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "C:\Program Files\Python35\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Program Files\Python35\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Program Files\Python35\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "leech.py", line 152, in download
    story = open_story(site, url, session, login, options)
  File "leech.py", line 103, in open_story
    story = handler.extract(url)
  File "C:\snipped\leech\sites\fictionlive.py", line 60, in extract
    for vote in segment['votes']:
KeyError: 'votes'
```

Discovered the final choice option had no choice or votes nodes. So now, if there's no votes inside the choice, skip it.

Example from the failure above:
```
{
  "_id": "c3gDXaqQhbwvQYCXK",
  "sid": "Q95BoG6GyPuXbytYg",
  "nt": "choice",
  "o": "0",
  "custom": true,
  "multiple": true,
  "w": 0,
  "ct": 1538442474557,
  "rt": 1538442474557,
  "ut": 1546208248749,
  "u": [
    {
      "n": "beleagueredqm",
      "a": "https://ddx5i92cqts4o.cloudfront.net/images/1bgk4902d_Sharingan.jpg",
      "_id": "WpoKaWXWZvgNPBcHa"
    }
  ],
  "p": 18,
  "lr": {
    "r": [
      "Q95BoG6GyPuXbytYg",
      "c3gDXaqQhbwvQYCXK"
    ],
    "nt": "chat",
    "b": ">This is a funeral, not a sniper rifle\nnever heard that sentence before",
    "ra": {
      "hide": true,
      "_id": "c3gDXaqQhbwvQYCXK",
      "b": "chapter c3gDXaqQhbwvQYCXK"
    },
    "ct": 1546208248749,
    "rt": 1546208248749,
    "ut": 1546208248749,
    "u": [
      {
        "n": "averant",
        "_id": "DGfvYctxeCAjQoSKA"
      }
    ],
    "_id": "ZpcpndQ4fFmDP8kcz"
  },
  "closed": "closed"
}
```