### PR TITLE
provide "leech" as a runnable script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Turn a story on certain websites into an ebook for convenient rea
 authors = ["David Lynch <kemayo@gmail.com>"]
 license = "MIT License"
 
+[tool.poetry.scripts]
+leech = "leech:cli"
+
 [tool.poetry.dependencies]
 python = "^3.6"
 attrs = "^20.2.0"


### PR DESCRIPTION
This makes it so that after `poetry install`, you can run the script as `leech` instead of `python3 leech.py`.