### PR TITLE
consistent locations for cache and configuration files

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "attrs"
 version = "20.2.0"
 description = "Classes Without Boilerplate"
@@ -233,6 +241,10 @@ python-versions = "^3.6"
 content-hash = "54948af9a16f0815d3ea732eecc7e089ed5c0ce237b1adfefcaf4f22ce6ffeea"
 
 [metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
 attrs = [
     {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
     {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT License"
 
 [tool.poetry.dependencies]
 python = "^3.6"
+appdirs = "^1.4.4"
 attrs = "^20.2.0"
 beautifulsoup4 = "^4.9.3"
 click-default-group = "^1.2.2"


### PR DESCRIPTION
This establishes consistent locations for the configuration and cache files instead of looking for them in whatever the current working directory happens to be.

It makes use of [AppDirs](https://github.com/ActiveState/appdirs) to pick appropriate places. 

To avoid directly interacting with the request cache by filename, this patch removes explicit use of sqlite to vacuum the cache file; requests-cache does that itself as of 0.5.1.