### PR TITLE
Made arbitrary sites no longer leak memory and fixed worm epub.

### DIFF
--- a/examples/worm.json
+++ b/examples/worm.json
@@ -1,9 +1,11 @@
 {
-	"url": "https://parahumans.wordpress.com/table-of-contents/",
+	"url": "https://parahumans.wordpress.com/2011/06/11/1-1/",
 	"title": "Worm",
 	"author": "Wildbow",
-	"chapter_selector": "#main .entry-content  a",
-	"content_selector": "#main .entry-content",
+	"content_selector": "#main",
+	"content_title_selector": "h1.entry-title",
+	"content_text_selector": ".entry-content",
 	"filter_selector": ".sharedaddy, style, a[href*='parahumans.wordpress.com']",
+	"next_selector": "a[rel=\"next\"]",
 	"cover_url": "https://pre00.deviantart.net/969a/th/pre/i/2015/051/8/7/worm_cover_by_cactusfantastico-d8ivj4b.png"
 }

--- a/sites/arbitrary.py
+++ b/sites/arbitrary.py
@@ -126,6 +126,9 @@ class Arbitrary(Site):
 
             # TODO: consider `'\n'.join(map(str, content.contents))`
             content.name = 'div'
+            
+            # Extract from bs4 tree so the rest of the tree gets deleted.
+            content = content.extract()
 
             chapters.append(Chapter(
                 title=title,

--- a/sites/arbitrary.py
+++ b/sites/arbitrary.py
@@ -126,7 +126,7 @@ class Arbitrary(Site):
 
             # TODO: consider `'\n'.join(map(str, content.contents))`
             content.name = 'div'
-            
+
             # Extract from bs4 tree so the rest of the tree gets deleted.
             content = content.extract()
 


### PR DESCRIPTION
Each `Chapter` object had a reference to the entire page tree, meaning that the program rose in RAM usage by a lot.
I reached 2 GB of ram trying to download all of the practical guide into a single epub - and then crashed on the second to last chapter due to MemoryError.

Transformed Worm to be with next_selector so the chapters are correctly ordered, E.2 is not skipped and the download does not crush due to `?share=twitter` url matched before.
Fixed Worm titles - now all chapters have a title.

If you are interested, I can also include json examples for Pact, Pale, Twig, the entire Guide and Unsong.