### PR TITLE
Stable seed generation for Sections

### DIFF
--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -2,6 +2,7 @@
 import click
 import glob
 import os
+import random
 import uuid
 import time
 import logging
@@ -14,8 +15,9 @@ logger.addHandler(logging.NullHandler())
 _sites = []
 
 
-def _default_uuid_string(*args):
-    return str(uuid.uuid4())
+def _default_uuid_string(self):
+    rd = random.Random(x=self.url)
+    return str(uuid.UUID(int=rd.getrandbits(8*16), version=4))
 
 
 @attr.s
@@ -23,7 +25,6 @@ class Chapter:
     title = attr.ib()
     contents = attr.ib()
     date = attr.ib(default=False)
-    id = attr.ib(default=attr.Factory(_default_uuid_string), converter=str)
 
 
 @attr.s
@@ -32,7 +33,7 @@ class Section:
     author = attr.ib()
     url = attr.ib()
     cover_url = attr.ib(default='')
-    id = attr.ib(default=attr.Factory(_default_uuid_string), converter=str)
+    id = attr.ib(default=attr.Factory(_default_uuid_string, takes_self=True), converter=str)
     contents = attr.ib(default=attr.Factory(list))
     footnotes = attr.ib(default=attr.Factory(list))
     summary = attr.ib(default='')


### PR DESCRIPTION
Good evening,

currently when generating an epub a Section uuid will be randomly generated. (See: [sites/__init__.py#L18](https://github.com/kemayo/leech/blob/dfa298dd3bc3234148cd07273a10fce157d76af6/sites/__init__.py#L18) ).
The uuid will be used as folder name to store content (See: [ebook/__init__.py#L93](https://github.com/kemayo/leech/blob/dfa298dd3bc3234148cd07273a10fce157d76af6/ebook/__init__.py#L93) ).

When I use a Toline Shine 3 to read an epub and then redownload and update the epub on the device, the Tolino 'forgets' my currently viewed page. The reason for this is that the viewed html file does not exist anymore because the
uuid changed. (Scenario: erraticerrata currently writes A Practical Guide to Evil
Do Wrong Right 7 and I update my epub version every time new chapters are released )

This pull request uses the Sections/Chapter title to seed the uuid generation. Therefor the same uuid will be generated with every download and the Tolino is able to open the last viewed page after updating the epub.

I don't know if the title is the best seed for the uuid but I think its probably the most stable identification for a book wich is still updated.

(https://github.com/JimmXinu/FanFicFare generates chapters directly in the OEBPS folder i.e. I dont know the epub specs but I dont know if there even is a reason to store the files in an randomly named folder?) 

Have a nice day
-ClaasJG