### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,19 @@
-FROM alpine:latest as install
+FROM alpine:latest
 
 # Package list taken from Pillow documentation:
 # https://pillow.readthedocs.io/en/stable/installation.html#building-on-linux
 RUN apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
     libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-    libxcb-dev libpng-dev gcc musl-dev python3 python3-dev  py3-pip py3-cryptography
-
-FROM install as poetry
-
-# We don't need poetry in the final container.
-RUN pip install poetry
+    libxcb-dev libpng-dev gcc musl-dev python3 python3-dev py3-pip py3-cryptography \
+    && pip install poetry
 
 COPY . /leech
 
-RUN cd /leech && poetry export > requirements.txt
-
-FROM install
-
-COPY --from=poetry /leech /leech
-RUN pip3 install -r /leech/requirements.txt
+RUN cd /leech \
+    && poetry config virtualenvs.create false \
+    && poetry install --no-dev
 
 WORKDIR /work
 
 ENTRYPOINT ["/leech/leech.py"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:latest as install
+
+# Package list taken from Pillow documentation:
+# https://pillow.readthedocs.io/en/stable/installation.html#building-on-linux
+RUN apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
+    libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
+    libxcb-dev libpng-dev gcc musl-dev python3 python3-dev  py3-pip py3-cryptography
+
+FROM install as poetry
+
+# We don't need poetry in the final container.
+RUN pip install poetry
+
+COPY . /leech
+
+RUN cd /leech && poetry export > requirements.txt
+
+FROM install
+
+COPY --from=poetry /leech /leech
+RUN pip3 install -r /leech/requirements.txt
+
+WORKDIR /work
+
+ENTRYPOINT ["/leech/leech.py"]

--- a/README.markdown
+++ b/README.markdown
@@ -127,6 +127,21 @@ Adding new site handers
 
 To add support for a new site, create a file in the `sites` directory that implements the `Site` interface. Take a look at `ao3.py` for a minimal example of what you have to do.
 
+Docker
+---
+
+You can build the project's Docker container like this:
+
+```shell
+docker build . -t kemayo/leech:snapshot
+```
+
+The container's entrypoint runs `leech` directly and sets the current working directory to `/work`, so you can mount any directory there:
+
+```shell
+docker run -it --rm -v ${DIR}:/work kemayo/leech:snapshot download [[URL]]
+```
+
 Contributing
 ---
 


### PR DESCRIPTION
I suspect that this project does not really need a Dockerfile, but as someone who does not use Python frequently, I did not want to install `poetry` and my usual solution is Docker containers. I'm also not very familiar with `poetry`, so building a Dockerfile that suited my needs (`leech` as the bare entrypoint, could be run in any directory, not just the project directory) was surprisingly difficult. Running the project from `poetry shell` was not possible in a Docker container. `poetry run` made it impossible to change the current working directory. I also had a lot of trouble getting `pillow` working fully until I looked up its package list in its documentation. So I figured I'd offer my work to the project.

I didn't set up any CI because I think only the maintainer can do that.