### PR TITLE
Update Practical Guide example json

### DIFF
--- a/examples/practical1.json
+++ b/examples/practical1.json
@@ -2,7 +2,7 @@
     "url": "https://practicalguidetoevil.wordpress.com/2015/03/25/prologue/",
     "title": "A Practical Guide To Evil: Book 1",
     "author": "erraticerrata",
-    "content_selector": "#main .entry-wrapper",
+    "content_selector": "#main",
     "content_title_selector": "h1.entry-title",
     "content_text_selector": ".entry-content",
     "filter_selector": ".sharedaddy, .wpcnt, style",

--- a/examples/practical2.json
+++ b/examples/practical2.json
@@ -2,7 +2,7 @@
     "url": "https://practicalguidetoevil.wordpress.com/2015/11/04/prologue-2/",
     "title": "A Practical Guide To Evil: Book 2",
     "author": "erraticerrata",
-    "content_selector": "#main .entry-wrapper",
+    "content_selector": "#main",
     "content_title_selector": "h1.entry-title",
     "content_text_selector": ".entry-content",
     "filter_selector": ".sharedaddy, .wpcnt, style",

--- a/examples/practical4.json
+++ b/examples/practical4.json
@@ -2,7 +2,7 @@
     "url": "https://practicalguidetoevil.wordpress.com/2018/04/09/prologue-4/",
     "title": "A Practical Guide To Evil: Book 4",
     "author": "erraticerrata",
-    "content_selector": "#main .entry-wrapper",
+    "content_selector": "#main",
     "content_title_selector": "h1.entry-title",
     "content_text_selector": ".entry-content",
     "filter_selector": ".sharedaddy, .wpcnt, style",

--- a/examples/practical5.json
+++ b/examples/practical5.json
@@ -2,7 +2,7 @@
     "url": "https://practicalguidetoevil.wordpress.com/2019/01/14/prologue-5/",
     "title": "A Practical Guide To Evil: Book 5",
     "author": "erraticerrata",
-    "content_selector": "#main .entry-wrapper",
+    "content_selector": "#main",
     "content_title_selector": "h1.entry-title",
     "content_text_selector": ".entry-content",
     "filter_selector": ".sharedaddy, .wpcnt, style",

--- a/examples/practical6.json
+++ b/examples/practical6.json
@@ -2,7 +2,7 @@
     "url": "https://practicalguidetoevil.wordpress.com/2020/01/06/prologue-6/",
     "title": "A Practical Guide To Evil: Book 6",
     "author": "erraticerrata",
-    "content_selector": "#main .entry-wrapper",
+    "content_selector": "#main",
     "content_title_selector": "h1.entry-title",
     "content_text_selector": ".entry-content",
     "filter_selector": ".sharedaddy, .wpcnt, style",

--- a/examples/practical7.json
+++ b/examples/practical7.json
@@ -1,6 +1,6 @@
 {
-    "url": "https://practicalguidetoevil.wordpress.com/2017/02/08/prologue-3/",
-    "title": "A Practical Guide To Evil: Book 3",
+    "url": "https://practicalguidetoevil.wordpress.com/2021/03/02/prologue-7/",
+    "title": "A Practical Guide To Evil: Book 7",
     "author": "erraticerrata",
     "content_selector": "#main",
     "content_title_selector": "h1.entry-title",

--- a/examples/practicalall.json
+++ b/examples/practicalall.json
@@ -2,7 +2,7 @@
     "url": "https://practicalguidetoevil.wordpress.com/2015/03/25/prologue/",
     "title": "A Practical Guide To Evil",
     "author": "erraticerrata",
-    "content_selector": "#main .entry-wrapper",
+    "content_selector": "#main",
     "content_title_selector": "h1.entry-title",
     "content_text_selector": ".entry-content",
     "filter_selector": ".sharedaddy, .wpcnt, style",


### PR DESCRIPTION
- Remove " .entry-wrapper" class from content_selector as the class doesn't exist on the Practical Guide website anymore.
- Add Practical Guide book 7 json file.