### PR TITLE
Add “Pale Lights”

### DIFF
--- a/examples/pale-lights.json
+++ b/examples/pale-lights.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://palelights.com/2022/08/17/chapter-1/",
+    "title": "Pale Lights",
+    "author": "erraticerrata",
+    "content_selector": "#main",
+    "content_title_selector": "h1.entry-title",
+    "content_text_selector": ".entry-content",
+    "filter_selector": ".sharedaddy, .wpcnt, style",
+    "next_selector": "a[rel=\"next\"]",
+    "cover_url": "https://www.royalroadcdn.com/public/covers-large/pale-lights-aaaay6-1-bi.jpg"
+}


### PR DESCRIPTION
Adds the new ongoing erraticerrata web serial “Pale Lights”.

Same WordPress structure as “A Practical Guide to Evil”. I didn’t verify the `filter_selector`, but looks good to me!

The cover is a lower res version of [this one](https://www.deviantart.com/gwennafran/art/Pale-Lights-Royal-Road-Cover-951582809), we could update to a higher res version if you want.

Once there’s individual books, we can use individual covers, e.g. [this one for book one](https://www.reddit.com/r/PaleLights/comments/pjp0ep/fan_book_cover_based_on_the_official_art/)