### PR TITLE
update docker recipe for python changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM alpine:latest
 # https://pillow.readthedocs.io/en/stable/installation.html#building-on-linux
 RUN apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
     libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-    libxcb-dev libpng-dev gcc musl-dev python3 python3-dev py3-pip py3-cryptography \
-    && pip install poetry
+    libxcb-dev libpng-dev gcc musl-dev python3 python3-dev py3-pip py3-cryptography
+RUN pip3 config set global.break-system-packages true && pip3 install poetry
 
 COPY . /leech
 
 RUN cd /leech \
     && poetry config virtualenvs.create false \
-    && poetry install --no-dev
+    && poetry install --without dev
 
 WORKDIR /work
 


### PR DESCRIPTION
Python being the moving target that it is, the Docker recipe needed a few updates:
1. Allow root usage of pip (now disabled by default)
2. change in poetry option syntax

The revised recipe builds correctly for me, avoiding errors that occurred because of the above two points. (I also separated the pip commands into their own layer for faster testing.)