### PR TITLE
Handle multiple entries in next_link

### DIFF
--- a/sites/arbitrary.py
+++ b/sites/arbitrary.py
@@ -77,6 +77,7 @@ class Arbitrary(Site):
             # set of already processed urls. Stored to detect loops.
             found_content_urls = set()
             content_url = definition.url
+
             def process_content_url(content_url):
                 if content_url in found_content_urls:
                     return False
@@ -97,6 +98,7 @@ class Arbitrary(Site):
                             if status:
                                 break
                 return True
+
             process_content_url(content_url)
 
         if not story:

--- a/sites/arbitrary.py
+++ b/sites/arbitrary.py
@@ -79,7 +79,7 @@ class Arbitrary(Site):
             content_url = definition.url
             def process_content_url(content_url):
                 if content_url in found_content_urls:
-                    return
+                    return False
                 found_content_urls.add(content_url)
                 for chapter in self._chapter(content_url, definition):
                     story.add(chapter)
@@ -92,7 +92,11 @@ class Arbitrary(Site):
                             if base:
                                 next_link_url = self._join_url(base, next_link_url)
                             content_url = self._join_url(content_url, next_link_url)
-                            process_content_url(content_url)
+                            # stop loop once a new link is found
+                            status = process_content_url(content_url)
+                            if status:
+                                break
+                return True
             process_content_url(content_url)
 
         if not story:

--- a/sites/arbitrary.py
+++ b/sites/arbitrary.py
@@ -80,25 +80,20 @@ class Arbitrary(Site):
 
             def process_content_url(content_url):
                 if content_url in found_content_urls:
-                    return False
+                    return None
                 found_content_urls.add(content_url)
                 for chapter in self._chapter(content_url, definition):
                     story.add(chapter)
-                return True
+                return content_url
 
             while content_urls:
-                status = False
-                for content_url in content_urls:
+                for temp_url in content_urls:
                     # stop inner loop once a new link is found
-                    status = process_content_url(content_url)
-                    if status:
+                    if content_url := process_content_url(temp_url):
                         break
-                # stop outer loop if no new links found
-                if not status:
-                    break
                 # reset url list
                 content_urls = []
-                if definition.next_selector:
+                if content_url and definition.next_selector:
                     soup, base = self._soup(content_url)
                     next_link = soup.select(definition.next_selector)
                     if next_link:
@@ -107,8 +102,6 @@ class Arbitrary(Site):
                             if base:
                                 next_link_url = self._join_url(base, next_link_url)
                             content_urls.append(self._join_url(content_url, next_link_url))
-
-            process_content_url(content_url)
 
         if not story:
             raise SiteException("No story content found; check the content selectors")


### PR DESCRIPTION
I wanted to use `next_selector` on a site with the following setup:

`story_part_2.html`:
```html
<a href="story_part_1.html">Previous</a>
<a href="story_part_3.html">Next</a>
```

i.e. no obvious attributes to distinguish the "previous" link from the "next" link.

The actual algorithm to process the next link does include loop detection, so it can disregard the "previous" link if it shows up as a match. However, only `next_link[0]` was checked. I reimplemented this as a recursive function that loops over all entries in `next_link` and stops once it finds a new one. (It could keep going, but the flow here did not make sense: having multiple new entries in `next_link` leads to an ambiguity, as they could be processed depth-first or breadth-first, and in any case, it seemed contrary to the logic of `next_selector`.)