### PR TITLE
Change idiom 'python3 leech.py' -> 'poetry run leech'

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,6 @@ My recommended setup process is:
 
     $ pip install poetry
     $ poetry install
-    $ poetry shell
 
 ...adjust as needed. Just make sure the dependencies from `pyproject.toml` get installed somehow.
 
@@ -21,21 +20,21 @@ Usage
 
 Basic
 
-    $ python3 leech.py [[URL]]
+    $ poetry run leech [[URL]]
 
 A new file will appear named `Title of the Story.epub`.
 
 This is equivalent to the slightly longer
 
-    $ python3 leech.py download [[URL]]
+    $ poetry run leech download [[URL]]
 
 Flushing the cache
 
-    $ python3 leech.py flush
+    $ poetry run leech flush
 
 Learn about other options
 
-    $ python3 leech.py --help
+    $ poetry run leech --help
 
 If you want to put an ePub on a Kindle you'll have to either use Amazon's send-to-kindle tools or convert it. For the latter I'd recommend [Calibre](http://calibre-ebook.com/), though you could also try using [kindlegen](http://www.amazon.com/gp/feature.html?docId=1000765211) directly.
 


### PR DESCRIPTION
See:  #103 

This PR does not only change the `poetry shell` section.
It also changes the basic examples to use `poetry run`.

I can see why you may want to keep the `python3 leech.py` part - feel free to discard this PR.

- ClaasJG

<details>
  <summary>Log</summary>
  <pre>
 ~  git clone git@github.com:kemayo/leech.git && cd leech
Cloning into 'leech'...
remote: Enumerating objects: 1712, done.
remote: Counting objects: 100% (367/367), done.
remote: Compressing objects: 100% (79/79), done.
remote: Total 1712 (delta 313), reused 300 (delta 288), pack-reused 1345 (from 2)
Receiving objects: 100% (1712/1712), 450.05 KiB | 1.56 MiB/s, done.
Resolving deltas: 100% (1106/1106), done.
 ~/leech   master  poetry install
Creating virtualenv leech-JcsXAoiK-py3.13 in /home/claasjg/.cache/pypoetry/virtualenvs
Installing dependencies from lock file

Package operations: 23 installs, 0 updates, 0 removals

  - Installing attrs (25.1.0)
  - Installing certifi (2024.8.30)
  - Installing charset-normalizer (3.4.0)
  - Installing idna (3.10)
  - Installing six (1.16.0)
  - Installing urllib3 (2.5.0)
  - Installing requests (2.32.4)
  - Installing click (8.1.8)
  - Installing cattrs (24.1.2)
  - Installing pycodestyle (2.11.1)
  - Installing platformdirs (4.3.6)
  - Installing pyflakes (3.1.0)
  - Installing mccabe (0.7.0)
  - Installing soupsieve (2.6)
  - Installing typing-extensions (4.12.2)
  - Installing url-normalize (1.4.3)
  - Installing beautifulsoup4 (4.13.3)
  - Installing click-default-group (1.2.4)
  - Installing flake8 (6.1.0)
  - Installing lxml (5.3.1)
  - Installing mintotp (0.3.0)
  - Installing pillow (11.1.0)
  - Installing requests-cache (1.2.1)

Installing the current project: leech (1.0.0)
 ~/leech   master  poetry run leech --help
Usage: leech [OPTIONS] COMMAND [ARGS]...

  Top level click group. Uses click-default-group to preserve most behavior
  from leech v1.

Options:
  --help  Show this message and exit.

Commands:
  download*  Downloads a story and saves it on disk as an epub ebook.
  flush      Flushes the contents of the cache.
 </pre>
</details>
